### PR TITLE
fix: missing backticks on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ error("This is an error message");
 | `{statusCode}` | HTTP status | `200`, `404` |
 | `{duration}` | Request time | `123ms` |
 | `{ip}` | Client IP | `127.0.0.1` |
+````
 
 ## 🎯 Examples
 


### PR DESCRIPTION
**Before:**
<img width="417" height="298" alt="Screenshot 2568-10-02 at 16 51 10" src="https://github.com/user-attachments/assets/8e1c4a94-6c88-407e-be5e-3d82c2f057ff" />

**After:**
<img width="492" height="401" alt="Screenshot 2568-10-02 at 16 52 07" src="https://github.com/user-attachments/assets/d7529731-1dbc-4e13-a4bd-ae0e64eb61f9" />
